### PR TITLE
Add batch reprocess endpoint and improve OCR field extraction

### DIFF
--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -133,7 +133,7 @@ async def process_invoice(invoice_id: int, db: AsyncSession) -> bool:
         has_conflicts = any(d['needs_review'] for d in diffs)
 
         # Check for missing critical fields (these require review)
-        critical_fields = ['invoice_number', 'issue_date', 'total_with_tax', 'seller_name']
+        critical_fields = ['invoice_number', 'issue_date', 'total_with_tax', 'buyer_name', 'seller_name']
         missing_critical = any(not final_fields.get(f) for f in critical_fields)
 
         needs_review = has_conflicts or missing_critical


### PR DESCRIPTION
## Summary
- Add `POST /invoices/batch-reprocess` endpoint to clear old OCR/LLM parsing results and reprocess selected invoices from scratch
- Add `buyer_name` to critical fields that require review when missing
- Add fallback regex patterns for `buyer_name` and `seller_name` extraction to handle various Chinese invoice formats where primary patterns fail
- Add debug logging for OCR text and extraction results to aid troubleshooting

## Test plan
- [ ] Test batch reprocess endpoint with multiple invoices
- [ ] Verify old OCR/LLM results are cleared before reprocessing
- [ ] Test fallback patterns match buyer/seller names on invoices where primary patterns fail
- [ ] Verify invoices with missing buyer_name now trigger review status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch reprocessing functionality to reload and reinitialize invoice extraction for multiple invoices simultaneously.

* **Improvements**
  * Enhanced invoice validation to include buyer name as a critical required field.
  * Improved data extraction for Chinese invoices with fallback pattern matching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->