### PR TITLE
Enable base URL config and connectivity testing for all LLM providers

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,10 +19,12 @@ class Settings(BaseSettings):
     # Anthropic (Claude)
     anthropic_api_key: str = ""
     anthropic_model: str = "claude-3-haiku-20240307"
+    anthropic_base_url: str = ""  # Custom base URL (e.g., for proxy)
 
     # Google (Gemini)
     google_api_key: str = ""
     google_model: str = "gemini-1.5-flash"
+    google_base_url: str = ""  # Custom base URL (e.g., for proxy)
 
     # Qwen (Alibaba)
     qwen_api_key: str = ""
@@ -37,6 +39,7 @@ class Settings(BaseSettings):
     # Zhipu (GLM)
     zhipu_api_key: str = ""
     zhipu_model: str = "glm-4-flash"
+    zhipu_base_url: str = ""  # Custom base URL (e.g., for proxy)
 
     # File upload
     max_file_size: int = 10 * 1024 * 1024  # 10MB

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -307,63 +307,175 @@ def _get_provider_base_url(provider_name: str) -> Optional[str]:
     return url_map.get(provider_name) or None
 
 
-class URLTestRequest(BaseModel):
-    """Request to test URL connectivity."""
-    url: str
+class ConfigTestRequest(BaseModel):
+    """Request to test LLM config before saving."""
+    provider: str
+    api_key: str
+    model: Optional[str] = None
+    base_url: Optional[str] = None
 
 
-class URLTestResponse(BaseModel):
-    """Response for URL connectivity test."""
+class ConfigTestResponse(BaseModel):
+    """Response for config test."""
     success: bool
     message: str
-    status_code: Optional[int] = None
     response_time_ms: Optional[int] = None
 
 
-@router.post("/llm/test-url", response_model=URLTestResponse)
-async def test_url_connectivity(request: URLTestRequest):
-    """Test if a URL endpoint is reachable (pre-save connectivity check)."""
-    import httpx
+# Default base URLs for providers that require them
+_DEFAULT_BASE_URLS = {
+    "qwen": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "deepseek": "https://api.deepseek.com",
+}
+
+
+def _test_openai_compatible(client, model: str) -> str:
+    """Test an OpenAI-compatible client, with fallback to Responses API."""
+    try:
+        # Try Chat Completions API first (standard OpenAI)
+        stream = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Reply with exactly: OK"},
+            ],
+            temperature=0.1,
+            max_tokens=10,
+            stream=True,
+        )
+        parts = []
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                parts.append(chunk.choices[0].delta.content)
+        return "".join(parts).strip()
+    except Exception as e:
+        err_msg = str(e)
+        # If proxy doesn't support Chat Completions, try Responses API
+        if "Unsupported parameter" not in err_msg and "messages" not in err_msg.lower():
+            raise
+        # Fall back to Responses API (used by Codex-compatible proxies)
+        if not hasattr(client, 'responses'):
+            raise RuntimeError(
+                "此代理使用 Responses API，但当前 openai SDK 版本不支持。"
+                "请升级: pip install -U openai"
+            ) from e
+        stream = client.responses.create(
+            model=model,
+            input=[{"role": "user", "content": "Reply with exactly: OK"}],
+            stream=True,
+        )
+        parts = []
+        for event in stream:
+            if getattr(event, 'type', '') == 'response.output_text.delta':
+                parts.append(event.delta)
+        return "".join(parts).strip()
+
+
+@router.post("/llm/test-config", response_model=ConfigTestResponse)
+async def test_llm_config(request: ConfigTestRequest):
+    """Test LLM configuration before saving using the actual provider client library."""
     import time
 
-    url = request.url.strip().rstrip("/")
-    if not url:
-        raise HTTPException(status_code=400, detail="URL不能为空")
+    provider = request.provider.lower()
+    if provider not in PROVIDERS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"不支持的LLM提供商: {provider}。支持的提供商: {', '.join(PROVIDERS.keys())}"
+        )
 
-    if not url.startswith(("http://", "https://")):
-        raise HTTPException(status_code=400, detail="URL必须以 http:// 或 https:// 开头")
+    if not request.api_key:
+        raise HTTPException(status_code=400, detail="API密钥不能为空")
 
+    model = request.model or DEFAULT_MODELS.get(provider, "")
+    base_url = request.base_url.strip().rstrip("/") if request.base_url else None
+
+    start = time.monotonic()
     try:
-        start = time.monotonic()
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            try:
-                response = await client.head(url)
-            except httpx.HTTPStatusError:
-                response = await client.get(url)
-        elapsed_ms = int((time.monotonic() - start) * 1000)
+        if provider in ("openai", "qwen", "deepseek"):
+            from openai import OpenAI
+            kwargs = {"api_key": request.api_key}
+            effective_url = base_url or _DEFAULT_BASE_URLS.get(provider)
+            if effective_url:
+                kwargs["base_url"] = effective_url
+            # Override User-Agent for custom base URLs to avoid Cloudflare WAF
+            # blocking the default "OpenAI/Python" user agent
+            if base_url:
+                kwargs["default_headers"] = {"User-Agent": "python-httpx/0.27.0"}
+            client = OpenAI(**kwargs)
+            result_text = _test_openai_compatible(client, model)
 
-        return URLTestResponse(
+        elif provider == "anthropic":
+            import anthropic
+            kwargs = {"api_key": request.api_key}
+            if base_url:
+                kwargs["base_url"] = base_url
+            client = anthropic.Anthropic(**kwargs)
+            response = client.messages.create(
+                model=model,
+                max_tokens=10,
+                system="You are a helpful assistant.",
+                messages=[{"role": "user", "content": "Reply with exactly: OK"}],
+            )
+            result_text = response.content[0].text.strip()
+
+        elif provider == "google":
+            import google.generativeai as genai
+            configure_kwargs = {"api_key": request.api_key}
+            if base_url:
+                configure_kwargs["client_options"] = {"api_endpoint": base_url}
+            genai.configure(**configure_kwargs)
+            gmodel = genai.GenerativeModel(model)
+            response = gmodel.generate_content("Reply with exactly: OK")
+            result_text = response.text.strip()
+
+        elif provider == "zhipu":
+            from zhipuai import ZhipuAI
+            kwargs = {"api_key": request.api_key}
+            if base_url:
+                kwargs["base_url"] = base_url
+            client = ZhipuAI(**kwargs)
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Reply with exactly: OK"},
+                ],
+                temperature=0.1,
+                max_tokens=10,
+            )
+            result_text = response.choices[0].message.content.strip()
+
+        else:
+            raise HTTPException(status_code=400, detail=f"不支持的LLM提供商: {provider}")
+
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        return ConfigTestResponse(
             success=True,
-            message=f"URL可达，状态码: {response.status_code}",
-            status_code=response.status_code,
+            message=f"连接成功，响应: {result_text[:50]}",
             response_time_ms=elapsed_ms,
         )
-    except httpx.ConnectError:
-        return URLTestResponse(
-            success=False,
-            message="无法连接到该地址，请检查URL是否正确",
-        )
-    except httpx.TimeoutException:
-        return URLTestResponse(
-            success=False,
-            message="连接超时，请检查URL是否正确或网络是否通畅",
-        )
+
     except Exception as e:
-        logger.error(f"URL connectivity test failed: {e}")
-        return URLTestResponse(
-            success=False,
-            message=f"连接测试失败: {str(e)}",
-        )
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        error_msg = str(e)
+        if "401" in error_msg or "Unauthorized" in error_msg or "authentication" in error_msg.lower():
+            msg = "API密钥无效或未授权"
+        elif "403" in error_msg or "Forbidden" in error_msg:
+            msg = "API密钥权限不足或访问被拒绝"
+        elif "404" in error_msg or "Not Found" in error_msg:
+            msg = "API地址无效，请检查URL是否正确（对于OpenAI兼容接口，base_url通常需要包含 /v1 路径）"
+        elif "connect" in error_msg.lower() or "timeout" in error_msg.lower():
+            msg = "无法连接到该地址，请检查URL和网络连接"
+        elif "<!DOCTYPE" in error_msg or "<html" in error_msg:
+            msg = "API地址返回了网页而非API响应，请检查URL是否正确"
+        elif "model" in error_msg.lower() and ("not found" in error_msg.lower() or "does not exist" in error_msg.lower()):
+            msg = f"模型不存在，请检查模型名称是否正确"
+        else:
+            # Clean up error message - remove HTML and limit length
+            clean_msg = error_msg.split('\n')[0][:150]
+            msg = f"测试失败: {clean_msg}"
+        logger.error(f"Config test failed for {provider}: {e}")
+        return ConfigTestResponse(success=False, message=msg, response_time_ms=elapsed_ms)
 
 
 class ModelInfo(BaseModel):

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -92,6 +92,7 @@ class LLMProviderInfo(BaseModel):
     display_name: str
     is_configured: bool
     model: Optional[str] = None
+    base_url: Optional[str] = None
 
 
 class LLMStatusResponse(BaseModel):
@@ -156,6 +157,7 @@ async def get_llm_status():
             display_name=PROVIDER_DISPLAY_NAMES.get(name, name),
             is_configured=name in configured_providers,
             model=_get_provider_model(name) if name in configured_providers else DEFAULT_MODELS.get(name),
+            base_url=_get_provider_base_url(name) if name in configured_providers else None,
         )
         available_providers.append(provider_info)
 
@@ -199,11 +201,11 @@ async def configure_llm(
         # Provider-specific configuration
         provider_config = {
             "openai": ("OPENAI_API_KEY", "OPENAI_MODEL", "OPENAI_BASE_URL"),
-            "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_MODEL", None),
-            "google": ("GOOGLE_API_KEY", "GOOGLE_MODEL", None),
+            "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_MODEL", "ANTHROPIC_BASE_URL"),
+            "google": ("GOOGLE_API_KEY", "GOOGLE_MODEL", "GOOGLE_BASE_URL"),
             "qwen": ("QWEN_API_KEY", "QWEN_MODEL", "QWEN_BASE_URL"),
             "deepseek": ("DEEPSEEK_API_KEY", "DEEPSEEK_MODEL", "DEEPSEEK_BASE_URL"),
-            "zhipu": ("ZHIPU_API_KEY", "ZHIPU_MODEL", None),
+            "zhipu": ("ZHIPU_API_KEY", "ZHIPU_MODEL", "ZHIPU_BASE_URL"),
         }
 
         key_name, model_name, base_url_name = provider_config[provider]
@@ -289,6 +291,79 @@ def _get_provider_model(provider_name: str) -> Optional[str]:
         "zhipu": settings.zhipu_model,
     }
     return model_map.get(provider_name)
+
+
+def _get_provider_base_url(provider_name: str) -> Optional[str]:
+    """Get the configured base URL for a provider."""
+    settings = get_settings()
+    url_map = {
+        "openai": settings.openai_base_url,
+        "anthropic": settings.anthropic_base_url,
+        "google": settings.google_base_url,
+        "qwen": settings.qwen_base_url,
+        "deepseek": settings.deepseek_base_url,
+        "zhipu": settings.zhipu_base_url,
+    }
+    return url_map.get(provider_name) or None
+
+
+class URLTestRequest(BaseModel):
+    """Request to test URL connectivity."""
+    url: str
+
+
+class URLTestResponse(BaseModel):
+    """Response for URL connectivity test."""
+    success: bool
+    message: str
+    status_code: Optional[int] = None
+    response_time_ms: Optional[int] = None
+
+
+@router.post("/llm/test-url", response_model=URLTestResponse)
+async def test_url_connectivity(request: URLTestRequest):
+    """Test if a URL endpoint is reachable (pre-save connectivity check)."""
+    import httpx
+    import time
+
+    url = request.url.strip().rstrip("/")
+    if not url:
+        raise HTTPException(status_code=400, detail="URL不能为空")
+
+    if not url.startswith(("http://", "https://")):
+        raise HTTPException(status_code=400, detail="URL必须以 http:// 或 https:// 开头")
+
+    try:
+        start = time.monotonic()
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            try:
+                response = await client.head(url)
+            except httpx.HTTPStatusError:
+                response = await client.get(url)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+
+        return URLTestResponse(
+            success=True,
+            message=f"URL可达，状态码: {response.status_code}",
+            status_code=response.status_code,
+            response_time_ms=elapsed_ms,
+        )
+    except httpx.ConnectError:
+        return URLTestResponse(
+            success=False,
+            message="无法连接到该地址，请检查URL是否正确",
+        )
+    except httpx.TimeoutException:
+        return URLTestResponse(
+            success=False,
+            message="连接超时，请检查URL是否正确或网络是否通畅",
+        )
+    except Exception as e:
+        logger.error(f"URL connectivity test failed: {e}")
+        return URLTestResponse(
+            success=False,
+            message=f"连接测试失败: {str(e)}",
+        )
 
 
 class ModelInfo(BaseModel):

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -197,7 +197,10 @@ class AnthropicProvider(BaseLLMProvider):
             with self._lock:
                 if self._client is None:
                     import anthropic
-                    self._client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+                    kwargs = {"api_key": settings.anthropic_api_key}
+                    if settings.anthropic_base_url:
+                        kwargs["base_url"] = settings.anthropic_base_url
+                    self._client = anthropic.Anthropic(**kwargs)
         return self._client
 
     def is_configured(self) -> bool:
@@ -263,7 +266,12 @@ class GoogleProvider(BaseLLMProvider):
             with self._lock:
                 if self._genai is None:
                     import google.generativeai as genai
-                    genai.configure(api_key=settings.google_api_key)
+                    configure_kwargs = {"api_key": settings.google_api_key}
+                    if settings.google_base_url:
+                        configure_kwargs["client_options"] = {
+                            "api_endpoint": settings.google_base_url
+                        }
+                    genai.configure(**configure_kwargs)
                     self._genai = genai
         return self._genai
 
@@ -424,7 +432,10 @@ class ZhipuProvider(BaseLLMProvider):
             with self._lock:
                 if self._client is None:
                     from zhipuai import ZhipuAI
-                    self._client = ZhipuAI(api_key=settings.zhipu_api_key)
+                    kwargs = {"api_key": settings.zhipu_api_key}
+                    if settings.zhipu_base_url:
+                        kwargs["base_url"] = settings.zhipu_base_url
+                    self._client = ZhipuAI(**kwargs)
         return self._client
 
     def is_configured(self) -> bool:

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -132,6 +132,9 @@ class OpenAIProvider(BaseLLMProvider):
                     kwargs = {"api_key": settings.openai_api_key}
                     if settings.openai_base_url:
                         kwargs["base_url"] = settings.openai_base_url
+                        # Override User-Agent for custom base URLs to avoid
+                        # Cloudflare WAF blocking "OpenAI/Python" user agent
+                        kwargs["default_headers"] = {"User-Agent": "python-httpx/0.27.0"}
                     self._client = OpenAI(**kwargs)
         return self._client
 

--- a/frontend/src/components/LLMConfigModal.tsx
+++ b/frontend/src/components/LLMConfigModal.tsx
@@ -20,7 +20,7 @@ import {
   ApiOutlined,
   EyeOutlined,
 } from '@ant-design/icons';
-import { getLLMStatus, configureLLM, testLLMConnection, getAvailableModels } from '../services/api';
+import { getLLMStatus, configureLLM, testLLMConnection, testURLConnectivity, getAvailableModels } from '../services/api';
 import type { LLMStatusResponse, LLMProviderInfo, ModelInfo } from '../types/invoice';
 
 interface LLMConfigModalProps {
@@ -59,12 +59,10 @@ const FALLBACK_MODELS: Record<string, ModelInfo[]> = {
   ],
 };
 
-// Providers that support custom base URL
-const SUPPORTS_BASE_URL = ['openai', 'qwen', 'deepseek'];
-
 function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
   const [loading, setLoading] = useState(true);
   const [testing, setTesting] = useState(false);
+  const [testingUrl, setTestingUrl] = useState(false);
   const [configuring, setConfiguring] = useState(false);
   const [status, setStatus] = useState<LLMStatusResponse | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<string>('');
@@ -125,11 +123,13 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
     await fetchModels(provider);
     // Set default model from fetched list
     const providerModels = FALLBACK_MODELS[provider] || [];
+    // Pre-populate base_url from saved config if available
+    const savedProvider = status?.available_providers.find(p => p.name === provider);
     form.setFieldsValue({
       provider,
       model: providerModels[0]?.id || '',
       api_key: '',
-      base_url: '',
+      base_url: savedProvider?.base_url || '',
       config_token: '',
     });
   };
@@ -179,6 +179,34 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
       message.error('配置失败');
     } finally {
       setConfiguring(false);
+    }
+  };
+
+  const handleTestUrl = async () => {
+    const url = form.getFieldValue('base_url');
+    if (!url?.trim()) {
+      message.warning('请先输入 API 地址');
+      return;
+    }
+    setTestingUrl(true);
+    try {
+      const result = await testURLConnectivity(url.trim());
+      if (result.success) {
+        message.success(`${result.message} (${result.response_time_ms}ms)`);
+      } else {
+        message.error(result.message);
+      }
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'response' in error) {
+        const axiosError = error as { response?: { data?: { detail?: string } } };
+        if (axiosError.response?.data?.detail) {
+          message.error(axiosError.response.data.detail);
+          return;
+        }
+      }
+      message.error('URL测试失败');
+    } finally {
+      setTestingUrl(false);
     }
   };
 
@@ -348,15 +376,26 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
               />
             </Form.Item>
 
-            {SUPPORTS_BASE_URL.includes(selectedProvider) && (
-              <Form.Item
-                name="base_url"
-                label="自定义 API 地址 (可选)"
-                tooltip="用于兼容OpenAI接口的其他服务"
-              >
-                <Input placeholder="例如: https://api.example.com/v1" />
-              </Form.Item>
-            )}
+            <Form.Item
+              name="base_url"
+              label="自定义 API 地址 (可选)"
+              tooltip="用于自定义API端点或代理服务"
+            >
+              <Input
+                placeholder="例如: https://api.example.com/v1"
+                addonAfter={
+                  <Button
+                    type="link"
+                    size="small"
+                    onClick={handleTestUrl}
+                    loading={testingUrl}
+                    style={{ margin: '-4px -11px', padding: '0 8px' }}
+                  >
+                    测试
+                  </Button>
+                }
+              />
+            </Form.Item>
 
             <Form.Item
               name="config_token"

--- a/frontend/src/components/LLMConfigModal.tsx
+++ b/frontend/src/components/LLMConfigModal.tsx
@@ -12,6 +12,7 @@ import {
   Tag,
   Divider,
   Tooltip,
+  AutoComplete,
 } from 'antd';
 import {
   SettingOutlined,
@@ -20,7 +21,7 @@ import {
   ApiOutlined,
   EyeOutlined,
 } from '@ant-design/icons';
-import { getLLMStatus, configureLLM, testLLMConnection, testURLConnectivity, getAvailableModels } from '../services/api';
+import { getLLMStatus, configureLLM, testLLMConfig, getAvailableModels } from '../services/api';
 import type { LLMStatusResponse, LLMProviderInfo, ModelInfo } from '../types/invoice';
 
 interface LLMConfigModalProps {
@@ -61,8 +62,7 @@ const FALLBACK_MODELS: Record<string, ModelInfo[]> = {
 
 function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
   const [loading, setLoading] = useState(true);
-  const [testing, setTesting] = useState(false);
-  const [testingUrl, setTestingUrl] = useState(false);
+  const [testingConfig, setTestingConfig] = useState(false);
   const [configuring, setConfiguring] = useState(false);
   const [status, setStatus] = useState<LLMStatusResponse | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<string>('');
@@ -134,12 +134,11 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
     });
   };
 
-  // Update form model when models are fetched
+  // Update form model when models are fetched (only if empty)
   useEffect(() => {
     if (models.length > 0 && selectedProvider) {
       const currentModel = form.getFieldValue('model');
-      // If current model not in list, set to first available
-      if (!currentModel || !models.find(m => m.id === currentModel)) {
+      if (!currentModel) {
         form.setFieldsValue({ model: models[0].id });
       }
     }
@@ -182,15 +181,24 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
     }
   };
 
-  const handleTestUrl = async () => {
-    const url = form.getFieldValue('base_url');
-    if (!url?.trim()) {
-      message.warning('请先输入 API 地址');
+  const handleTestConfig = async () => {
+    const values = form.getFieldsValue();
+    if (!values.provider) {
+      message.warning('请先选择LLM提供商');
       return;
     }
-    setTestingUrl(true);
+    if (!values.api_key?.trim()) {
+      message.warning('请先输入API密钥');
+      return;
+    }
+    setTestingConfig(true);
     try {
-      const result = await testURLConnectivity(url.trim());
+      const result = await testLLMConfig({
+        provider: values.provider,
+        api_key: values.api_key.trim(),
+        model: values.model || undefined,
+        base_url: values.base_url?.trim() || undefined,
+      });
       if (result.success) {
         message.success(`${result.message} (${result.response_time_ms}ms)`);
       } else {
@@ -204,30 +212,9 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
           return;
         }
       }
-      message.error('URL测试失败');
+      message.error('配置测试失败');
     } finally {
-      setTestingUrl(false);
-    }
-  };
-
-  const handleTest = async () => {
-    setTesting(true);
-    try {
-      const result = await testLLMConnection();
-      if (result.success) {
-        message.success(`${result.provider_display} 连接测试成功`);
-      }
-    } catch (error: unknown) {
-      if (error && typeof error === 'object' && 'response' in error) {
-        const axiosError = error as { response?: { data?: { detail?: string } } };
-        if (axiosError.response?.data?.detail) {
-          message.error(axiosError.response.data.detail);
-          return;
-        }
-      }
-      message.error('连接测试失败');
-    } finally {
-      setTesting(false);
+      setTestingConfig(false);
     }
   };
 
@@ -282,11 +269,6 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
               type="success"
               showIcon={false}
               style={{ marginBottom: 16 }}
-              action={
-                <Button size="small" onClick={handleTest} loading={testing}>
-                  测试连接
-                </Button>
-              }
             />
           ) : (
             <Alert
@@ -356,10 +338,9 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
                 </Space>
               }
             >
-              <Select
-                placeholder="选择模型"
+              <AutoComplete
+                placeholder={modelsLoading ? '加载模型列表...' : '选择或输入模型名称'}
                 allowClear
-                loading={modelsLoading}
                 options={models.map((m) => ({
                   label: (
                     <Space>
@@ -373,6 +354,9 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
                   ),
                   value: m.id,
                 }))}
+                filterOption={(input, option) =>
+                  (option?.value as string)?.toLowerCase().includes(input.toLowerCase())
+                }
               />
             </Form.Item>
 
@@ -381,20 +365,7 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
               label="自定义 API 地址 (可选)"
               tooltip="用于自定义API端点或代理服务"
             >
-              <Input
-                placeholder="例如: https://api.example.com/v1"
-                addonAfter={
-                  <Button
-                    type="link"
-                    size="small"
-                    onClick={handleTestUrl}
-                    loading={testingUrl}
-                    style={{ margin: '-4px -11px', padding: '0 8px' }}
-                  >
-                    测试
-                  </Button>
-                }
-              />
+              <Input placeholder="例如: https://api.example.com/v1" />
             </Form.Item>
 
             <Form.Item
@@ -408,6 +379,12 @@ function LLMConfigModal({ open, onClose, onConfigured }: LLMConfigModalProps) {
             <Form.Item style={{ marginBottom: 0, marginTop: 24 }}>
               <Space style={{ width: '100%', justifyContent: 'flex-end' }}>
                 <Button onClick={onClose}>取消</Button>
+                <Button
+                  onClick={handleTestConfig}
+                  loading={testingConfig}
+                >
+                  测试配置
+                </Button>
                 <Button
                   type="primary"
                   onClick={handleConfigure}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -190,6 +190,14 @@ export const testLLMConnection = async (): Promise<LLMTestResponse> => {
   return response.data;
 };
 
+// Test URL connectivity (pre-save check)
+export const testURLConnectivity = async (
+  url: string
+): Promise<{ success: boolean; message: string; status_code?: number; response_time_ms?: number }> => {
+  const response = await api.post('/settings/llm/test-url', { url });
+  return response.data;
+};
+
 // Get available models for a provider
 export const getAvailableModels = async (
   provider?: string,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -190,11 +190,11 @@ export const testLLMConnection = async (): Promise<LLMTestResponse> => {
   return response.data;
 };
 
-// Test URL connectivity (pre-save check)
-export const testURLConnectivity = async (
-  url: string
-): Promise<{ success: boolean; message: string; status_code?: number; response_time_ms?: number }> => {
-  const response = await api.post('/settings/llm/test-url', { url });
+// Test LLM config before saving (uses actual provider client library)
+export const testLLMConfig = async (
+  config: { provider: string; api_key: string; model?: string; base_url?: string }
+): Promise<{ success: boolean; message: string; response_time_ms?: number }> => {
+  const response = await api.post('/settings/llm/test-config', config);
   return response.data;
 };
 

--- a/frontend/src/types/invoice.ts
+++ b/frontend/src/types/invoice.ts
@@ -120,6 +120,7 @@ export interface LLMProviderInfo {
   display_name: string;
   is_configured: boolean;
   model: string | null;
+  base_url: string | null;
 }
 
 export interface LLMStatusResponse {


### PR DESCRIPTION
Extends LLM provider configuration to support custom base URLs for all 6 providers (OpenAI, Anthropic, Google, Qwen, DeepSeek, Zhipu) instead of just 3. Adds a new POST /llm/test-url endpoint to test URL connectivity before saving configuration. Updates the frontend modal to show the base_url field for all providers with an inline test button. Pre-populates saved base_url values when switching between providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable base URL fields for Anthropic, Google, and Zhipu providers.
  * New "Test configuration" action to validate provider settings (including base URL) and show response time.
  * LLM configuration UI now always shows and persists a base URL input, pre-filled when switching providers.
  * Provider status and model listings include richer model details (name, vision support, context length, pricing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->