### PR TITLE
docs: add portable 12-rule behavioral template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->
+
+## Scope & Grounding
+
+State assumptions explicitly. Ask one clarifying question when ambiguity changes the implementation path, target, or deliverable. Do not ask when the uncertainty can be resolved by reading files or running safe commands.
+
+Define success criteria before multi-step work or any code change. State what "done" looks like and the verification commands. Loop until verified against that criteria.
+
+Checkpoint after each significant step. Summarize what was done, what is verified, and what is left. If you lose track, stop and restate.
+
+## Verification & Evidence
+
+Use evidence. When making a claim about repository behavior, cite a file path and line number or say it is a hypothesis.
+
+Never fabricate command output. Run the command, preserve the important output, and state clearly when a command cannot be run.
+
+Read before you write. Before adding code in a file, read its exports, immediate callers, and shared utilities. "Looks orthogonal" is the most dangerous assumption — if unsure why code is structured a certain way, ask.
+
+Tests must verify intent, not just behavior. Every test must encode the business invariant it protects. A test that still passes after the meaningful business rule changes is shallow.
+
+Never claim completion if anything was skipped or unverified. Default to surfacing uncertainty, not hiding it.
+
+Separate product facts from telemetry. Logs, traces, and metrics help diagnose behavior; durable product state belongs in ledgers.
+
+## Code Discipline
+
+Simplicity first. Do not add abstractions, configuration, feature flags, new dependencies, or generalized helpers unless the current task needs them more than once. Minimum code that solves the problem.
+
+Surgical changes. Touch only what the task requires. Do not "improve" adjacent code, comments, or formatting. Clean up only your own mess. Match existing style.
+
+Match codebase conventions, even when you disagree. Conformance beats taste inside the codebase. If you think a convention is harmful, surface it as a separate discussion — do not fork it silently.
+
+When codebase patterns conflict, choose the more recent, more tested, or more locally dominant pattern. State which constraint made the choice true. Flag the other pattern for cleanup. Do not blend conflicting patterns.
+
+Use the model for judgment over ambiguous or unstructured input. Classification, summarization, extraction from unstructured text — yes. Routing, retries, validation, counting, sorting, parsing structured data, status-code handling — write code instead.
+
+Do not lock implementation details too early. Framework presets are allowed, but the core loop must remain portable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->
+## Rule Conflicts
+
+When rules conflict: user's explicit instruction wins over everything. Project-level rules win over global. Within the same file, the more specific rule wins over the general one. Never silently blend conflicting rules — surface the conflict, state which rule you are following and why, and flag the other for review.


### PR DESCRIPTION
## Summary
- Adds portable behavioral rules from harness-template to CLAUDE.md and AGENTS.md
- New sections: Scope & Grounding, Verification & Evidence, Code Discipline, Rule Conflicts
- Appends to existing files without overwriting repo-specific content

## Changes
- **AGENTS.md**: Added Scope & Grounding, Verification & Evidence, and Code Discipline sections
- **CLAUDE.md**: Added Rule Conflicts section